### PR TITLE
fix: replace node:22-alpine with wolfi-base + nodejs-22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ FROM scratch AS license
 COPY LICENSE /LICENSE
 COPY NOTICE /NOTICE
 
-FROM cgr.dev/chainguard/node:22 AS builder
+FROM cgr.dev/chainguard/wolfi-base AS builder
 USER root
+RUN apk add --no-cache nodejs-22 npm
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci && npm install @rolldown/binding-linux-x64-gnu --no-save
@@ -13,13 +14,15 @@ RUN npm run build
 
 FROM cgr.dev/chainguard/wolfi-base AS runner
 USER root
-RUN apk add --no-cache nodejs
+RUN apk add --no-cache nodejs-22 npm
 WORKDIR /app
 COPY --from=license / /
 COPY package.json package-lock.json ./
 RUN npm ci --omit=dev && npm install @rolldown/binding-linux-x64-gnu --no-save
 COPY --from=builder /app/dist ./dist
-RUN mkdir -p /app/data && adduser -D -u 1000 appuser && chown -R appuser:appuser /app
+RUN mkdir -p /app/data && \
+    adduser -D -u 1000 appuser && \
+    chown -R appuser:appuser /app
 USER appuser
 EXPOSE 8000
 CMD ["node", "dist/index.js"]


### PR DESCRIPTION
Switch from `node:22-alpine` to `cgr.dev/chainguard/wolfi-base` with `nodejs-22` installed via apk, since a dedicated chainguard node base image is not available.

- Builder and runner stages now share the same wolfi-base image
- Pins Node.js to v22 via the `nodejs-22` package  
- Includes npm in both stages for dependency installation