### PR TITLE
fix: use OFF Search-a-licious API with retry and backoff (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,11 @@ It's recommended to install it next to your Mealie instance using docker-compose
 |---|---|---|
 | `MEALIE_URL` | `http://mealie:9000` | Mealie instance URL |
 | `MEALIE_API_TOKEN` | — | **Required.** Mealie service account token |
-| `OFF_LANGUAGE` | `de` | Open Food Facts language |
+| `OFF_LANGUAGE` | `de` | Open Food Facts search language(s) |
+| `OFF_SEARCH_BASE_URL` | `https://search.openfoodfacts.org` | Open Food Facts search API base URL |
 | `OFF_BASE_URL` | `https://world.openfoodfacts.org` | Open Food Facts base URL |
+| `OFF_MAX_RETRIES` | `3` | Retries for transient OFF search errors (429/5xx) |
+| `OFF_RETRY_BACKOFF_MS` | `500` | Base backoff between retries (doubles each attempt) |
 | `LLM_ENABLED` | `false` | Enable LLM fallback for custom units and unmatched foods |
 | `LLM_API_KEY` | — | API key for OpenAI-compatible endpoint |
 | `LLM_BASE_URL` | `https://api.mistral.ai/v1` | LLM API base URL |

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,10 +11,13 @@ export const config = {
 
   openFoodFacts: {
     baseUrl: process.env.OFF_BASE_URL || "https://world.openfoodfacts.org",
+    searchBaseUrl: process.env.OFF_SEARCH_BASE_URL || "https://search.openfoodfacts.org",
     language: process.env.OFF_LANGUAGE || "de",
     searchRateLimit: parseInt(process.env.OFF_SEARCH_RATE_LIMIT || "10", 10),
     productRateLimit: parseInt(process.env.OFF_PRODUCT_RATE_LIMIT || "15", 10),
     cacheTtlMs: parseInt(process.env.OFF_CACHE_TTL || "86400", 10) * 1000,
+    maxRetries: parseInt(process.env.OFF_MAX_RETRIES || "3", 10),
+    retryBackoffMs: parseInt(process.env.OFF_RETRY_BACKOFF_MS || "500", 10),
     userAgent: process.env.OFF_USER_AGENT || `mealie-calorie-estimator/${version} (mail@timo-reymann.de)`,
   },
 

--- a/src/services/off-client.ts
+++ b/src/services/off-client.ts
@@ -2,7 +2,7 @@ import { config } from "../config.js"
 import { logger } from "../utils/logger.js"
 import { getCachedNutrients, setCachedNutrients } from "../utils/cache.js"
 import { waitForRateLimit, RateLimitType } from "../utils/rate-limiter.js"
-import type { OffNutriments, OffProduct, NutrientSet } from "../types.js"
+import type { OffNutriments, OffProduct, OffSearchResult, NutrientSet } from "../types.js"
 
 export interface OffLookupResult {
   nutrients: NutrientSet | null
@@ -10,19 +10,36 @@ export interface OffLookupResult {
   productName: string | null
 }
 
-const OFF_NUTRIENT_FIELDS = [
-  "product_name",
-  "nutriments.energy-kcal_100g",
-  "nutriments.proteins_100g",
-  "nutriments.carbohydrates_100g",
-  "nutriments.fat_100g",
-  "nutriments.saturated-fat_100g",
-  "nutriments.trans-fat_100g",
-  "nutriments.fiber_100g",
-  "nutriments.sugars_100g",
-  "nutriments.sodium_100g",
-  "nutriments.cholesterol_100g",
-].join(",")
+const OFF_NUTRIENT_FIELDS = ["product_name", "nutriments"].join(",")
+
+const RETRYABLE_STATUS = new Set([429, 500, 502, 503, 504])
+
+async function fetchWithRetry(url: string, query: string): Promise<Response | null> {
+  const { maxRetries, retryBackoffMs, userAgent } = config.openFoodFacts
+  let lastResponse: Response | null = null
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    if (attempt > 0) {
+      const delay = retryBackoffMs * 2 ** (attempt - 1)
+      logger.debug({ query, attempt, delay }, "Retrying OFF search after backoff")
+      await new Promise((resolve) => setTimeout(resolve, delay))
+    }
+
+    try {
+      const res = await fetch(url, { headers: { "User-Agent": userAgent } })
+      if (res.ok || !RETRYABLE_STATUS.has(res.status)) {
+        return res
+      }
+      lastResponse = res
+      logger.debug({ query, attempt, status: res.status }, "OFF search returned retryable status")
+    } catch (err) {
+      lastResponse = null
+      logger.debug({ query, attempt, err: (err as Error).message }, "OFF search request failed")
+    }
+  }
+
+  return lastResponse
+}
 
 function extractNutrients(n: OffNutriments): NutrientSet {
   const fat = n["fat_100g"] ?? null
@@ -53,39 +70,41 @@ function extractNutrients(n: OffNutriments): NutrientSet {
 
 async function searchProduct(query: string): Promise<OffProduct | null> {
   const params = new URLSearchParams({
-    search_terms: query,
-    lang: config.openFoodFacts.language,
+    q: query,
+    langs: config.openFoodFacts.language,
     page_size: "1",
-    json: "1",
     fields: OFF_NUTRIENT_FIELDS,
   })
 
-  const url = `${config.openFoodFacts.baseUrl}/cgi/search.pl?${params}`
+  const url = `${config.openFoodFacts.searchBaseUrl}/search?${params}`
 
   await waitForRateLimit(RateLimitType.Search)
 
-  const res = await fetch(url, {
-    headers: { "User-Agent": config.openFoodFacts.userAgent },
-  })
+  const res = await fetchWithRetry(url, query)
+
+  if (!res) {
+    logger.warn({ query }, "OFF search failed after retries")
+    return null
+  }
 
   if (!res.ok) {
     logger.warn({ status: res.status, query }, "OFF search returned error")
     return null
   }
 
-  let data: any
+  let data: OffSearchResult
   try {
-    data = await res.json()
+    data = (await res.json()) as OffSearchResult
   } catch {
     logger.warn({ query }, "OFF returned non-JSON response")
     return null
   }
 
-  if (!data.products || data.products.length === 0) {
+  if (!data.hits || data.hits.length === 0) {
     return null
   }
 
-  return data.products[0] as OffProduct
+  return data.hits[0]
 }
 
 export async function lookupNutrients(foodName: string, unitName?: string): Promise<OffLookupResult> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,8 +64,11 @@ export interface MealieRecipePatch {
 }
 
 export interface OffSearchResult {
-  count: number
-  products: OffProduct[]
+  hits: OffProduct[]
+  count?: number
+  page?: number
+  page_count?: number
+  page_size?: number
 }
 
 export interface OffProduct {

--- a/tests/off-client.test.ts
+++ b/tests/off-client.test.ts
@@ -1,14 +1,31 @@
 import { describe, it, expect, vi, beforeEach, beforeAll } from "vitest"
 import { lookupNutrients } from "../src/services/off-client.js"
 import { initCache, setCachedNutrients } from "../src/utils/cache.js"
+import { config } from "../src/config.js"
 
 beforeAll(async () => {
   await initCache()
+  config.openFoodFacts.retryBackoffMs = 1
 })
 
 beforeEach(() => {
   vi.restoreAllMocks()
 })
+
+function hitsResponse(nutriments: Record<string, number>, productName = "Milch") {
+  return new Response(JSON.stringify({ hits: [{ product_name: productName, nutriments }] }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  })
+}
+
+const MILK_NUTRIMENTS = {
+  "energy-kcal_100g": 48,
+  "proteins_100g": 3.5,
+  "carbohydrates_100g": 5,
+  "fat_100g": 1.5,
+  "saturated-fat_100g": 1,
+}
 
 describe("lookupNutrients", () => {
   it("returns cached value without calling API", async () => {
@@ -20,5 +37,44 @@ describe("lookupNutrients", () => {
     const result = await lookupNutrients("flour")
     expect(result.nutrients?.kcalPer100g).toBe(364)
     expect(result.matched).toBe(true)
+  })
+
+  it("queries the search API and parses hits", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(hitsResponse(MILK_NUTRIMENTS))
+
+    const result = await lookupNutrients("Milch")
+
+    expect(result.matched).toBe(true)
+    expect(result.nutrients?.kcalPer100g).toBe(48)
+    const calledUrl = fetchMock.mock.calls[0][0] as string
+    expect(calledUrl).toContain("/search?")
+    expect(calledUrl).toContain("q=Milch")
+    expect(calledUrl).toContain("langs=de")
+  })
+
+  it("retries on a 503 and succeeds on a later attempt", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("unavailable", { status: 503 }))
+      .mockResolvedValueOnce(new Response("unavailable", { status: 503 }))
+      .mockResolvedValueOnce(hitsResponse(MILK_NUTRIMENTS))
+
+    const result = await lookupNutrients("Wasser")
+
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(result.matched).toBe(true)
+    expect(result.nutrients?.kcalPer100g).toBe(48)
+  })
+
+  it("gives up after exhausting retries on persistent 503", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("unavailable", { status: 503 }))
+
+    const result = await lookupNutrients("Saft")
+
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+    expect(result.matched).toBe(false)
+    expect(result.nutrients).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

Fixes #6 — German ingredients (`Milch`, `Wasser`, …) intermittently failed with `status=503 msg=OFF search returned error`.

Root cause (verified manually with curl using the same headers): the legacy `/cgi/search.pl` endpoint on `world.openfoodfacts.org` intermittently returns a `503` "Page temporarily unavailable" HTML page under load. The same query succeeds on one attempt and 503s seconds later — so it's transient server-side throttling, **not** a German-language issue. This also explains why it "worked fine" for the maintainer.

## Changes

- **Switch to the maintained Search-a-licious API** (`https://search.openfoodfacts.org/search`) instead of the overloaded legacy `cgi/search.pl`.
- **Use the `langs` param** (plural), which also materially improves match quality (e.g. `Milch` → "Kakao Milch" / "Frische fettarme Milch" instead of roasted almonds).
- **Retry with exponential backoff** on transient failures (network errors + `429/500/502/503/504`), `500ms → 1s → 2s` by default. Non-retryable statuses pass through immediately; a warning is logged only after retries are exhausted.
- Parse the new `hits` response shape.
- New env vars: `OFF_SEARCH_BASE_URL`, `OFF_MAX_RETRIES`, `OFF_RETRY_BACKOFF_MS` (documented in README).

## Testing

- `npm run typecheck` — clean
- `npm test` — 97/97 pass (added 3 off-client tests: API query/params, retry-then-succeed on 503, give-up after exhausting retries)
- Live end-to-end via `lookupNutrients`: `Milch` → "Kakao Milch" (61 kcal), `Wasser` → "Mineralwasser" (0 kcal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)