### PR TITLE
fix: bump package.json version on release for accurate user agent

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -23,10 +23,18 @@
       }
     ],
     [
+      "@semantic-release/npm",
+      {
+        "npmPublish": false
+      }
+    ],
+    [
       "@semantic-release/git",
       {
         "assets": [
-          "CHANGELOG.md"
+          "CHANGELOG.md",
+          "package.json",
+          "package-lock.json"
         ]
       }
     ],


### PR DESCRIPTION
## Summary

Follow-up to #7. That change made the OFF User-Agent read `version` from `package.json` at runtime (`mealie-calorie-estimator/${version} (...)`), but the release process never bumped `package.json` — `@semantic-release/git` only committed `CHANGELOG.md`. As a result `package.json` is pinned at `1.0.0`, so the running service always reports `mealie-calorie-estimator/1.0.0` regardless of the actual release (1.5.1, …).

Verified: `package.json` `version` is `1.0.0` at both the `v1.5.0` and `v1.5.1` release commits.

## Change

- Add `@semantic-release/npm` with `npmPublish: false` so semantic-release writes the computed version into `package.json` / `package-lock.json` during `prepare` (no publish to the npm registry).
- Add `package.json` and `package-lock.json` to the `@semantic-release/git` assets so the bump is committed back with the release.

`@semantic-release/npm` ships bundled with semantic-release core (used via the CircleCI `trustedshops-public/semantic-release` orb's `with_existing_config`), so no new dependency is required.

## Effect

After the next release, the committed `package.json` version tracks the release tag, and the runtime User-Agent reflects the real version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)