### PR TITLE
feat: add per-household API token support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,10 @@
 MEALIE_URL=http://mealie:9000
 MEALIE_API_TOKEN=your-dedicated-service-account-token
 
+# Per-household API tokens (optional, overrides MEALIE_API_TOKEN)
+# Set a token for each household that needs a different account:
+# MEALIE_API_TOKEN_<HOUSEHOLD_ID>=your-household-specific-token
+
 # Open Food Facts
 OFF_LANGUAGE=de
 OFF_BASE_URL=https://world.openfoodfacts.org

--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ It's recommended to install it next to your Mealie instance using docker-compose
 | Variable | Default | Description |
 |---|---|---|
 | `MEALIE_URL` | `http://mealie:9000` | Mealie instance URL |
-| `MEALIE_API_TOKEN` | — | **Required.** Mealie service account token |
+| `MEALIE_API_TOKEN` | — | **Required.** Default Mealie service account token. Used unless a per-household token matches |
+| `MEALIE_API_TOKEN_<HOUSEHOLD_ID>` | — | Optional per-household token override. Set e.g. `MEALIE_API_TOKEN_my_household` to use a different token for recipes in that household. The household ID from the recipe response is uppercased and non-alphanumeric characters are replaced with `_` for lookup |
 | `OFF_LANGUAGE` | `de` | Open Food Facts search language(s) |
 | `OFF_SEARCH_BASE_URL` | `https://search.openfoodfacts.org` | Open Food Facts search API base URL |
 | `OFF_BASE_URL` | `https://world.openfoodfacts.org` | Open Food Facts base URL |

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 import { createRequire } from "module"
 const { version } = createRequire(import.meta.url)("../package.json")
 
-export function getMealieToken(householdId?: string): string {
+export function getMealieToken(householdId?: string | null): string {
   if (householdId) {
     const key =
       "MEALIE_API_TOKEN_" +

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,25 @@
 import { createRequire } from "module"
 const { version } = createRequire(import.meta.url)("../package.json")
 
+export function getMealieToken(householdId?: string): string {
+  if (householdId) {
+    const key =
+      "MEALIE_API_TOKEN_" +
+      householdId
+        .toUpperCase()
+        .replace(/[^A-Z0-9_]/g, "_")
+    const token = process.env[key]
+    if (token) return token
+  }
+
+  return config.mealie.apiToken
+}
+
+function hasAnyToken(): boolean {
+  if (process.env.MEALIE_API_TOKEN) return true
+  return Object.keys(process.env).some((k) => k.startsWith("MEALIE_API_TOKEN_"))
+}
+
 export const config = {
   port: parseInt(process.env.PORT || "8000", 10),
 
@@ -37,6 +56,8 @@ export const config = {
   logLevel: process.env.LOG_LEVEL || "info",
 }
 
-if (!config.mealie.apiToken) {
-  throw new Error("MEALIE_API_TOKEN is not set. Estimator cannot start without it.")
+if (!hasAnyToken()) {
+  throw new Error(
+    "No Mealie API token configured. Set MEALIE_API_TOKEN or at least one MEALIE_API_TOKEN_<HOUSEHOLD_ID> environment variable.",
+  )
 }

--- a/src/routes/backfill.ts
+++ b/src/routes/backfill.ts
@@ -33,23 +33,23 @@ async function processBackfill(): Promise<void> {
           }
 
           const perServing = perServingFromRecipeNutrition(recipe.nutrition)
-          const { tags, tagSlugs } = await resolveAndMergeTags(recipe, perServing)
+          const { tags, tagSlugs } = await resolveAndMergeTags(recipe, perServing, recipe.householdId)
           await patchRecipe(slug, {
             tags,
             extras: { ...recipe.extras, calorie_estimator_tags: JSON.stringify(tagSlugs) },
-          })
+          }, recipe.householdId)
           tagOnly++
           continue
         }
 
         if (hasManualCalories(recipe)) {
           const patch = buildManualAckPatch(recipe, hash)
-          await patchRecipe(slug, patch)
+          await patchRecipe(slug, patch, recipe.householdId)
           manual++
           continue
         }
 
-        await estimateAndTag(recipe, hash)
+        await estimateAndTag(recipe, hash, recipe.householdId)
         updated++
       } catch (err) {
         errors++

--- a/src/routes/estimate.ts
+++ b/src/routes/estimate.ts
@@ -10,7 +10,7 @@ async function processEstimate(slug: string): Promise<void> {
 
     const recipe = await getRecipe(slug)
     const hash = computeIngredientHash(recipe)
-    const { calories, tagSlugs } = await estimateAndTag(recipe, hash)
+    const { calories, tagSlugs } = await estimateAndTag(recipe, hash, recipe.householdId)
 
     logger.info({ slug, calories, tags: tagSlugs }, "On-demand estimation complete")
   } catch (err) {

--- a/src/routes/webhook.ts
+++ b/src/routes/webhook.ts
@@ -38,11 +38,11 @@ async function processWebhook(slug: string): Promise<void> {
       }
 
       const perServing = perServingFromRecipeNutrition(recipe.nutrition)
-      const { tags, tagSlugs } = await resolveAndMergeTags(recipe, perServing)
+      const { tags, tagSlugs } = await resolveAndMergeTags(recipe, perServing, recipe.householdId)
       await patchRecipe(slug, {
         tags,
         extras: { ...recipe.extras, calorie_estimator_tags: JSON.stringify(tagSlugs) },
-      })
+      }, recipe.householdId)
       logger.info({ slug, tags: tagSlugs }, "Added missing auto-tags")
       return
     }
@@ -50,11 +50,11 @@ async function processWebhook(slug: string): Promise<void> {
     if (hasManualCalories(recipe)) {
       logger.info({ slug, calories: recipe.nutrition?.calories }, "Manual calories detected, acknowledging without overwriting")
       const patch = buildManualAckPatch(recipe, hash)
-      await patchRecipe(slug, patch)
+      await patchRecipe(slug, patch, recipe.householdId)
       return
     }
 
-    const { calories, tagSlugs } = await estimateAndTag(recipe, hash)
+    const { calories, tagSlugs } = await estimateAndTag(recipe, hash, recipe.householdId)
     logger.info({ slug, calories, tags: tagSlugs }, "Updated recipe nutrition and tags")
   } catch (err) {
     logger.error({ slug, err }, "Webhook background processing failed")

--- a/src/services/mealie-client.ts
+++ b/src/services/mealie-client.ts
@@ -89,7 +89,7 @@ export async function getRecipe(slug: string): Promise<MealieRecipe> {
   return request<MealieRecipe>("GET", `/api/recipes/${slug}`)
 }
 
-export async function patchRecipe(slug: string, patch: MealieRecipePatch, householdId?: string): Promise<void> {
+export async function patchRecipe(slug: string, patch: MealieRecipePatch, householdId?: string | null): Promise<void> {
   logger.debug({ slug, patch, householdId }, "Patching recipe in Mealie")
   const token = getMealieToken(householdId)
   await request("PATCH", `/api/recipes/${slug}`, JSON.stringify(patch), token)
@@ -126,7 +126,7 @@ interface TagsPagination {
   total_pages: number
 }
 
-export async function getOrCreateTags(names: string[], householdId?: string): Promise<MealieTag[]> {
+export async function getOrCreateTags(names: string[], householdId?: string | null): Promise<MealieTag[]> {
   const tags: MealieTag[] = []
   const token = getMealieToken(householdId)
   for (const name of names) {

--- a/src/services/mealie-client.ts
+++ b/src/services/mealie-client.ts
@@ -1,6 +1,6 @@
 import http from "node:http"
 import https from "node:https"
-import { config } from "../config.js"
+import { config, getMealieToken } from "../config.js"
 import { logger } from "../utils/logger.js"
 import type { MealieRecipe, MealieRecipePatch, MealieTag } from "../types.js"
 
@@ -12,6 +12,7 @@ function request<T>(
   method: string,
   path: string,
   body?: string,
+  token?: string,
 ): Promise<T> {
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
@@ -27,7 +28,7 @@ function request<T>(
         method,
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${config.mealie.apiToken}`,
+          Authorization: `Bearer ${token ?? config.mealie.apiToken}`,
         },
         timeout: config.mealie.timeoutMs,
       },
@@ -88,9 +89,10 @@ export async function getRecipe(slug: string): Promise<MealieRecipe> {
   return request<MealieRecipe>("GET", `/api/recipes/${slug}`)
 }
 
-export async function patchRecipe(slug: string, patch: MealieRecipePatch): Promise<void> {
-  logger.debug({ slug, patch }, "Patching recipe in Mealie")
-  await request("PATCH", `/api/recipes/${slug}`, JSON.stringify(patch))
+export async function patchRecipe(slug: string, patch: MealieRecipePatch, householdId?: string): Promise<void> {
+  logger.debug({ slug, patch, householdId }, "Patching recipe in Mealie")
+  const token = getMealieToken(householdId)
+  await request("PATCH", `/api/recipes/${slug}`, JSON.stringify(patch), token)
 }
 
 export async function getAllRecipes(): Promise<string[]> {
@@ -124,14 +126,15 @@ interface TagsPagination {
   total_pages: number
 }
 
-export async function getOrCreateTags(names: string[]): Promise<MealieTag[]> {
+export async function getOrCreateTags(names: string[], householdId?: string): Promise<MealieTag[]> {
   const tags: MealieTag[] = []
+  const token = getMealieToken(householdId)
   for (const name of names) {
     try {
-      const tag = await request<MealieTag>("POST", "/api/organizers/tags", JSON.stringify({ name }))
+      const tag = await request<MealieTag>("POST", "/api/organizers/tags", JSON.stringify({ name }), token)
       tags.push(tag)
     } catch {
-      const all = await request<TagsPagination>("GET", "/api/organizers/tags?perPage=-1")
+      const all = await request<TagsPagination>("GET", "/api/organizers/tags?perPage=-1", undefined, token)
       const existing = all.items.find((t) => t.name === name)
       if (existing) {
         tags.push(existing)

--- a/src/services/tagging.ts
+++ b/src/services/tagging.ts
@@ -65,9 +65,10 @@ export function perServingFromRecipeNutrition(nutrition: MealieNutrition | null)
 export async function resolveAutoTags(
   recipe: MealieRecipe,
   perServing: NutrientSet,
+  householdId?: string,
 ): Promise<{ tags: MealieTag[]; slugs: string[] }> {
   const tagNames = computeTags(perServing)
-  const autoTags = await getOrCreateTags(tagNames)
+  const autoTags = await getOrCreateTags(tagNames, householdId)
   const oldSlugs: string[] = JSON.parse(recipe.extras?.calorie_estimator_tags || "[]")
   return { tags: autoTags, slugs: oldSlugs }
 }
@@ -91,8 +92,9 @@ export function tagsAreComplete(recipe: MealieRecipe): boolean {
 export async function resolveAndMergeTags(
   recipe: MealieRecipe,
   perServing: NutrientSet,
+  householdId?: string,
 ): Promise<{ tags: MealieTag[]; tagSlugs: string[] }> {
-  const { tags: autoTags, slugs: oldSlugs } = await resolveAutoTags(recipe, perServing)
+  const { tags: autoTags, slugs: oldSlugs } = await resolveAutoTags(recipe, perServing, householdId)
   const merged = mergeTags(recipe, autoTags, oldSlugs)
   return { tags: merged, tagSlugs: autoTags.map(t => t.slug) }
 }
@@ -100,14 +102,15 @@ export async function resolveAndMergeTags(
 export async function estimateAndTag(
   recipe: MealieRecipe,
   hash: string,
+  householdId?: string,
 ): Promise<{ calories: number | null; tagSlugs: string[] }> {
   const result = await estimateRecipe(recipe)
   const nutritionPatch = buildNutritionPatch(result, hash, recipe.recipeYield)
-  const { tags, tagSlugs } = await resolveAndMergeTags(recipe, result.perServingNutrients)
+  const { tags, tagSlugs } = await resolveAndMergeTags(recipe, result.perServingNutrients, householdId)
   await patchRecipe(recipe.slug, {
     ...nutritionPatch,
     tags,
     extras: { ...nutritionPatch.extras, calorie_estimator_tags: JSON.stringify(tagSlugs) },
-  })
+  }, householdId)
   return { calories: result.perServingNutrients.kcalPer100g, tagSlugs }
 }

--- a/src/services/tagging.ts
+++ b/src/services/tagging.ts
@@ -65,7 +65,7 @@ export function perServingFromRecipeNutrition(nutrition: MealieNutrition | null)
 export async function resolveAutoTags(
   recipe: MealieRecipe,
   perServing: NutrientSet,
-  householdId?: string,
+  householdId?: string | null,
 ): Promise<{ tags: MealieTag[]; slugs: string[] }> {
   const tagNames = computeTags(perServing)
   const autoTags = await getOrCreateTags(tagNames, householdId)
@@ -92,7 +92,7 @@ export function tagsAreComplete(recipe: MealieRecipe): boolean {
 export async function resolveAndMergeTags(
   recipe: MealieRecipe,
   perServing: NutrientSet,
-  householdId?: string,
+  householdId?: string | null,
 ): Promise<{ tags: MealieTag[]; tagSlugs: string[] }> {
   const { tags: autoTags, slugs: oldSlugs } = await resolveAutoTags(recipe, perServing, householdId)
   const merged = mergeTags(recipe, autoTags, oldSlugs)
@@ -102,7 +102,7 @@ export async function resolveAndMergeTags(
 export async function estimateAndTag(
   recipe: MealieRecipe,
   hash: string,
-  householdId?: string,
+  householdId?: string | null,
 ): Promise<{ calories: number | null; tagSlugs: string[] }> {
   const result = await estimateRecipe(recipe)
   const nutritionPatch = buildNutritionPatch(result, hash, recipe.recipeYield)

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,7 @@ export interface MealieRecipe {
   nutrition: MealieNutrition | null
   tags: MealieTag[] | null
   extras: Record<string, string> | null
+  householdId: string | null
 }
 
 export interface MealieRecipePatch {
@@ -74,6 +75,7 @@ export interface OffSearchResult {
 export interface OffProduct {
   product_name: string
   nutriments?: OffNutriments
+  nutriscore_grade?: string
 }
 
 export interface OffNutriments {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { getMealieToken } from "../src/config.js"
+
+const ORIGINAL_ENV = { ...process.env }
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV }
+})
+
+describe("getMealieToken", () => {
+  it("returns default MEALIE_API_TOKEN when no householdId given", () => {
+    const result = getMealieToken()
+    expect(result).toBe("test-token")
+  })
+
+  it("returns default MEALIE_API_TOKEN when householdId has no matching env var", () => {
+    const result = getMealieToken("nonexistent-household")
+    expect(result).toBe("test-token")
+  })
+
+  it("returns household-specific token when MEALIE_API_TOKEN_<ID> is set", () => {
+    process.env.MEALIE_API_TOKEN_HOUSEHOLD_123 = "house-token-123"
+    const result = getMealieToken("household-123")
+    expect(result).toBe("house-token-123")
+  })
+
+  it("falls back to default when household-specific env var is empty", () => {
+    process.env.MEALIE_API_TOKEN_OTHER = ""
+    const result = getMealieToken("other")
+    expect(result).toBe("test-token")
+  })
+
+  it("normalizes householdId to uppercase with underscores", () => {
+    process.env.MEALIE_API_TOKEN_ABC_DEF = "normalized-token"
+    const result = getMealieToken("abc-def")
+    expect(result).toBe("normalized-token")
+  })
+
+  it("treats householdId case-insensitively via normalization", () => {
+    process.env.MEALIE_API_TOKEN_MY_HOUSE = "case-token"
+    const result = getMealieToken("My-House")
+    expect(result).toBe("case-token")
+  })
+
+  it("replaces multiple special chars with underscores", () => {
+    process.env.MEALIE_API_TOKEN_A_B_C = "special-token"
+    const result = getMealieToken("a b.c")
+    expect(result).toBe("special-token")
+  })
+})

--- a/tests/estimator.test.ts
+++ b/tests/estimator.test.ts
@@ -12,6 +12,7 @@ function makeRecipe(overrides: Partial<MealieRecipe> = {}): MealieRecipe {
     nutrition: null,
     tags: [],
     extras: {},
+    householdId: null,
     ...overrides,
   }
 }

--- a/tests/manual-calories.test.ts
+++ b/tests/manual-calories.test.ts
@@ -19,6 +19,7 @@ function makeRecipe(overrides: Partial<MealieRecipe> = {}): MealieRecipe {
     nutrition: null,
     tags: [],
     extras: {},
+    householdId: null,
     ...overrides,
   }
 }

--- a/tests/tagging.test.ts
+++ b/tests/tagging.test.ts
@@ -32,6 +32,7 @@ function makeRecipe(tags: MealieTag[], extrasSlugs?: string[]): MealieRecipe {
     nutrition: null,
     tags,
     extras: extrasSlugs ? { calorie_estimator_tags: JSON.stringify(extrasSlugs) } : {},
+    householdId: null,
   }
 }
 


### PR DESCRIPTION
Add support for per-household Mealie API tokens via `MEALIE_API_TOKEN_<HOUSEHOLD_ID>` env vars. The default `MEALIE_API_TOKEN` remains as the fallback.

- New `getMealieToken(householdId)` helper resolves per-household tokens with uppercase-normalized env var names
- Relaxed startup guard (requires at least one token configured)
- Threaded householdId through mealie-client, tagging service, and all route handlers
- 7 new unit tests for token resolution and normalization
- Documented in README and .env.example