### PR TITLE
feat: add estimation strategy with opt-in tag-based filtering

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,12 @@ LLM_BASE_URL=https://api.mistral.ai/v1
 LLM_MODEL=mistral-small-latest
 LLM_RATE_LIMIT=30
 
+# Estimation strategy
+# "all" (default) — estimate every recipe
+# "tagged" — only estimate recipes with the tag specified by ESTIMATE_TAG
+ESTIMATE_STRATEGY=all
+ESTIMATE_TAG=estimate
+
 # Server
 PORT=8000
 LOG_LEVEL=info

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ It's recommended to install it next to your Mealie instance using docker-compose
 | `LLM_API_KEY` | — | API key for OpenAI-compatible endpoint |
 | `LLM_BASE_URL` | `https://api.mistral.ai/v1` | LLM API base URL |
 | `LLM_MODEL` | `mistral-small-latest` | Model name |
+| `ESTIMATE_STRATEGY` | `all` | Estimation strategy: `all` (estimate every recipe) or `tagged` (only estimate recipes with the `ESTIMATE_TAG` tag) |
+| `ESTIMATE_TAG` | `estimate` | Tag name to check when `ESTIMATE_STRATEGY=tagged` |
 | `PORT` | `8000` | Server port |
 | `LOG_LEVEL` | `info` | Pino log level |
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -54,6 +54,11 @@ export const config = {
     rateLimit: parseInt(process.env.LLM_RATE_LIMIT || "30", 10),
   },
 
+  estimate: {
+    strategy: (process.env.ESTIMATE_STRATEGY || "all") as "all" | "tagged",
+    tag: process.env.ESTIMATE_TAG || "estimate",
+  },
+
   cache: {
     dbPath: process.env.CACHE_DB_PATH || "data/cache.db",
   },

--- a/src/routes/backfill.ts
+++ b/src/routes/backfill.ts
@@ -4,6 +4,7 @@ import {
   computeIngredientHash,
   hasManualCalories,
   buildManualAckPatch,
+  shouldEstimate,
 } from "../services/estimator.js"
 import { perServingFromRecipeNutrition, tagsAreComplete, resolveAndMergeTags, estimateAndTag } from "../services/tagging.js"
 import { logger } from "../utils/logger.js"
@@ -17,12 +18,19 @@ async function processBackfill(): Promise<void> {
     let manual = 0
     let errors = 0
     let tagOnly = 0
+    let filtered = 0
 
     for (const slug of allSlugs) {
       processed++
 
       try {
         const recipe = await getRecipe(slug)
+
+        if (!shouldEstimate(recipe)) {
+          filtered++
+          continue
+        }
+
         const householdId = getRecipeHouseholdId(recipe)
         const hash = computeIngredientHash(recipe)
         const existingHash = recipe.extras?.calorie_estimator_hash
@@ -58,11 +66,11 @@ async function processBackfill(): Promise<void> {
       }
 
       if (processed % 10 === 0) {
-        logger.info({ processed, total: allSlugs.length, updated, skipped, manual, tagOnly, errors }, "Backfill progress")
+        logger.info({ processed, total: allSlugs.length, updated, skipped, manual, tagOnly, filtered, errors }, "Backfill progress")
       }
     }
 
-    logger.info({ processed, total: allSlugs.length, updated, skipped, manual, tagOnly, errors }, "Backfill complete")
+    logger.info({ processed, total: allSlugs.length, updated, skipped, manual, tagOnly, filtered, errors }, "Backfill complete")
   } catch (err) {
     logger.error({ err }, "Backfill background processing failed")
   }

--- a/src/routes/estimate.ts
+++ b/src/routes/estimate.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance } from "fastify"
 import { getRecipe, getRecipeHouseholdId } from "../services/mealie-client.js"
-import { computeIngredientHash } from "../services/estimator.js"
+import { computeIngredientHash, shouldEstimate } from "../services/estimator.js"
 import { estimateAndTag } from "../services/tagging.js"
 import { logger } from "../utils/logger.js"
 
@@ -9,6 +9,12 @@ async function processEstimate(slug: string): Promise<void> {
     logger.info({ slug }, "On-demand estimation processing")
 
     const recipe = await getRecipe(slug)
+
+    if (!shouldEstimate(recipe)) {
+      logger.info({ slug }, "Recipe skipped (not tagged for estimation)")
+      return
+    }
+
     const householdId = getRecipeHouseholdId(recipe)
     const hash = computeIngredientHash(recipe)
     const { calories, tagSlugs } = await estimateAndTag(recipe, hash, householdId)

--- a/src/routes/webhook.ts
+++ b/src/routes/webhook.ts
@@ -5,6 +5,7 @@ import {
   computeIngredientHash,
   hasManualCalories,
   buildManualAckPatch,
+  shouldEstimate,
 } from "../services/estimator.js"
 import { perServingFromRecipeNutrition, tagsAreComplete, resolveAndMergeTags, estimateAndTag } from "../services/tagging.js"
 import { logger } from "../utils/logger.js"
@@ -27,6 +28,12 @@ function normalizeEventData(raw: Record<string, unknown>): EventRecipeData {
 async function processWebhook(slug: string): Promise<void> {
   try {
     const recipe = await getRecipe(slug)
+
+    if (!shouldEstimate(recipe)) {
+      logger.info({ slug }, "Recipe skipped (not tagged for estimation)")
+      return
+    }
+
     const householdId = getRecipeHouseholdId(recipe)
 
     const hash = computeIngredientHash(recipe)

--- a/src/services/estimator.ts
+++ b/src/services/estimator.ts
@@ -3,6 +3,7 @@ import type {
   MealieRecipe, IngredientMatch, EstimateResult, NutritionPatch,
   NutrientSet, MealieNutrition,
 } from "../types.js"
+import { config } from "../config.js"
 import { convertToGrams } from "./unit-converter.js"
 import { lookupNutrients } from "./off-client.js"
 import { estimateGrams, estimateNutrients } from "./llm-estimator.js"
@@ -23,6 +24,12 @@ export function computeIngredientHash(recipe: MealieRecipe): string {
   parts.push(`servings:${recipe.recipeServings ?? ""}`)
   const hash = crypto.createHash("sha256").update(parts.join(",")).digest("hex")
   return hash
+}
+
+export function shouldEstimate(recipe: MealieRecipe): boolean {
+  if (config.estimate.strategy === "all") return true
+  const tagName = config.estimate.tag.toLowerCase()
+  return (recipe.tags || []).some(t => t.slug === tagName || t.name.toLowerCase() === tagName)
 }
 
 export function parseYield(recipeYield: string | null): number | null {

--- a/tests/strategy.test.ts
+++ b/tests/strategy.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import type { MealieRecipe } from "../src/types.js"
+
+function makeRecipe(tags: { slug: string; name: string }[] = []): MealieRecipe {
+  return {
+    slug: "test",
+    name: "Test",
+    recipeYield: null,
+    recipeServings: null,
+    recipeIngredient: [],
+    nutrition: null,
+    tags: tags.map(t => ({ id: t.slug, ...t, groupId: null })),
+    extras: {},
+    householdId: null,
+  }
+}
+
+describe("shouldEstimate", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    delete process.env.ESTIMATE_STRATEGY
+    delete process.env.ESTIMATE_TAG
+  })
+
+  it("defaults to all strategy when env var is not set", async () => {
+    const { shouldEstimate } = await import("../src/services/estimator.js")
+    expect(shouldEstimate(makeRecipe([]))).toBe(true)
+  })
+
+  it("returns true for all strategy regardless of tags", async () => {
+    process.env.ESTIMATE_STRATEGY = "all"
+    const { shouldEstimate } = await import("../src/services/estimator.js")
+    expect(shouldEstimate(makeRecipe([]))).toBe(true)
+    expect(shouldEstimate(makeRecipe([{ slug: "estimate", name: "estimate" }]))).toBe(true)
+    expect(shouldEstimate(makeRecipe([{ slug: "some-other", name: "some-other" }]))).toBe(true)
+  })
+
+  it("returns true for tagged strategy when recipe has the tag by slug", async () => {
+    process.env.ESTIMATE_STRATEGY = "tagged"
+    const { shouldEstimate } = await import("../src/services/estimator.js")
+    expect(shouldEstimate(makeRecipe([{ slug: "estimate", name: "Custom Name" }]))).toBe(true)
+  })
+
+  it("returns true for tagged strategy when recipe has the tag by name", async () => {
+    process.env.ESTIMATE_STRATEGY = "tagged"
+    const { shouldEstimate } = await import("../src/services/estimator.js")
+    expect(shouldEstimate(makeRecipe([{ slug: "custom-slug", name: "Estimate" }]))).toBe(true)
+  })
+
+  it("returns false for tagged strategy when recipe lacks the tag", async () => {
+    process.env.ESTIMATE_STRATEGY = "tagged"
+    const { shouldEstimate } = await import("../src/services/estimator.js")
+    expect(shouldEstimate(makeRecipe([]))).toBe(false)
+    expect(shouldEstimate(makeRecipe([{ slug: "other", name: "other" }]))).toBe(false)
+  })
+
+  it("returns false when recipe has null tags in tagged mode", async () => {
+    process.env.ESTIMATE_STRATEGY = "tagged"
+    const { shouldEstimate } = await import("../src/services/estimator.js")
+    const recipe = makeRecipe()
+    recipe.tags = null
+    expect(shouldEstimate(recipe)).toBe(false)
+  })
+
+  it("uses custom tag name from ESTIMATE_TAG", async () => {
+    process.env.ESTIMATE_STRATEGY = "tagged"
+    process.env.ESTIMATE_TAG = "calc"
+    const { shouldEstimate } = await import("../src/services/estimator.js")
+    expect(shouldEstimate(makeRecipe([{ slug: "calc", name: "calc" }]))).toBe(true)
+    expect(shouldEstimate(makeRecipe([{ slug: "estimate", name: "estimate" }]))).toBe(false)
+  })
+
+  it("handles case-insensitive tag matching", async () => {
+    process.env.ESTIMATE_STRATEGY = "tagged"
+    const { shouldEstimate } = await import("../src/services/estimator.js")
+    expect(shouldEstimate(makeRecipe([{ slug: "ESTIMATE", name: "ESTIMATE" }]))).toBe(true)
+    expect(shouldEstimate(makeRecipe([{ slug: "Estimate", name: "ESTIMATE" }]))).toBe(true)
+    expect(shouldEstimate(makeRecipe([{ slug: "estimate", name: "Estimate" }]))).toBe(true)
+  })
+})


### PR DESCRIPTION

## Summary

Adds a configurable estimation strategy (ESTIMATE_STRATEGY) that defaults to estimating all recipes, with the option to opt-in to only estimate recipes tagged with a specific tag.

## Changes

- **src/config.ts** — Added `estimate.strategy` (all/tagged) and `estimate.tag` config section
- **src/services/estimator.ts** — Added `shouldEstimate(recipe)` function that checks recipe tags against the configured strategy
- **src/routes/webhook.ts** — Skip processing when `shouldEstimate` returns false
- **src/routes/backfill.ts** — Skip processing with tracked `filtered` counter in progress logs
- **src/routes/estimate.ts** — Skip processing when `shouldEstimate` returns false
- **.env.example** — Document ESTIMATE_STRATEGY and ESTIMATE_TAG
- **README.md** — Added new env vars to the table
- **tests/strategy.test.ts** — 8 tests covering all strategy combinations, custom tag names, case-insensitive matching

## Usage

### Default behavior (unchanged — estimate all recipes):
ESTIMATE_STRATEGY=all

### Opt-in tag-based filtering:
ESTIMATE_STRATEGY=tagged
ESTIMATE_TAG=estimate   # optional, defaults to 'estimate'

When set to `tagged`, only recipes with the configured tag (matching by slug or name, case-insensitive) will be estimated. All others are skipped across webhook, on-demand, and backfill endpoints.

Closes #11
